### PR TITLE
Remove parens from withRelayMutations query name

### DIFF
--- a/src/components/decorators/withRelayMutations.js
+++ b/src/components/decorators/withRelayMutations.js
@@ -21,5 +21,5 @@ export default (mutations: Mutations) => (Component: WrappedComponent<*>): React
         return <Component {...props} {...mutationProps} />;
     }
     Wrapper.contextTypes = {relayEnv: RelayEnvContextType};
-    return wraps(Component, Wrapper, `WithRelayMutationsWrapping${Component.displayName || Component.name || Component.constructor.name}`);
+    return wraps(Component, Wrapper, `WithRelayMutations(${Component.displayName || Component.name || Component.constructor.name})`);
 };

--- a/src/components/decorators/withRelayMutations.js
+++ b/src/components/decorators/withRelayMutations.js
@@ -21,5 +21,5 @@ export default (mutations: Mutations) => (Component: WrappedComponent<*>): React
         return <Component {...props} {...mutationProps} />;
     }
     Wrapper.contextTypes = {relayEnv: RelayEnvContextType};
-    return wraps(Component, Wrapper, `WithRelayMutations(${Component.displayName || Component.name || Component.constructor.name})`);
+    return wraps(Component, Wrapper, `WithRelayMutationsWrapping${Component.displayName || Component.name || Component.constructor.name}`);
 };

--- a/src/components/decorators/withRelayQuery.js
+++ b/src/components/decorators/withRelayQuery.js
@@ -37,7 +37,7 @@ export default <P: Object>(
     // Grab the name from the component if it is not passed in manually
     const componentName = Component.displayName || Component.name || ((Component.constructor: any).name: any);
     name = name || componentName;
-    
+
     // Remove reserved characters
     name = name.replace(/\W/g, '');
 

--- a/src/components/decorators/withRelayQuery.js
+++ b/src/components/decorators/withRelayQuery.js
@@ -21,6 +21,12 @@ type Options<P> = {|
     isomorphic?: boolean
 |};
 
+function getComponentName(Component) {
+    if (Component.WrappedComponent) {
+        return getComponentName(Component.WrappedComponent);
+    }
+    return Component.displayName || Component.name || Component.constructor.name;
+}
 
 export default <P: Object>(
     {
@@ -35,11 +41,7 @@ export default <P: Object>(
     }: Options<P>
 ) => (Component: WrappedComponent<P>): ReactClass<P> => {
     // Grab the name from the component if it is not passed in manually
-    const componentName = Component.displayName || Component.name || ((Component.constructor: any).name: any);
-    name = name || componentName;
-
-    // Remove reserved characters
-    name = name.replace(/\W/g, '');
+    name = name || getComponentName(Component)
 
     // Split out queries and fragments from query
     const queries = {};

--- a/src/components/decorators/withRelayQuery.js
+++ b/src/components/decorators/withRelayQuery.js
@@ -37,6 +37,9 @@ export default <P: Object>(
     // Grab the name from the component if it is not passed in manually
     const componentName = Component.displayName || Component.name || ((Component.constructor: any).name: any);
     name = name || componentName;
+    
+    // Remove reserved characters
+    name = name.replace(/\W/g, '');
 
     // Split out queries and fragments from query
     const queries = {};

--- a/src/components/decorators/withRelayQuery.js
+++ b/src/components/decorators/withRelayQuery.js
@@ -41,7 +41,7 @@ export default <P: Object>(
     }: Options<P>
 ) => (Component: WrappedComponent<P>): ReactClass<P> => {
     // Grab the name from the component if it is not passed in manually
-    name = name || getComponentName(Component)
+    name = name || getComponentName(Component);
 
     // Split out queries and fragments from query
     const queries = {};


### PR DESCRIPTION
Avoids this bug:
![image](https://cloud.githubusercontent.com/assets/7237525/24605898/a8e892d2-1862-11e7-8b29-960e691fe714.png)
The parentheses are interpreted by graphql and it ignores the actual id. I've removed them and just changed it to what would be output as `WithRelayMutationsWrappingFunction`.